### PR TITLE
Fix NPM Completion Conflict and Add Support for pnpm/yarn Dependency Removal

### DIFF
--- a/getDependencies.js
+++ b/getDependencies.js
@@ -1,0 +1,8 @@
+const pkg = require(process.argv[2])
+
+const result = Object
+  .entries({ ...pkg.dependencies, ...pkg.devDependencies })
+  .map(entry => `${entry[0]}: ${entry[1]}`)
+  .join('\n')
+
+console.log(result)

--- a/getScripts.js
+++ b/getScripts.js
@@ -1,4 +1,3 @@
-
 const pkg = require(process.argv[2])
 
 const result = Object

--- a/getScripts.js
+++ b/getScripts.js
@@ -2,7 +2,6 @@ const pkg = require(process.argv[2])
 
 const result = Object
   .entries(pkg.scripts || {})
-  .filter(entry => /^\w/.test(entry[0]))
   .map(entry => {
     entry[0] = entry[0].replace(/([$:])/ig, '\\$1')
     entry[1] = entry[1].replace(/([$:])/ig, '\\$1')

--- a/zsh-npm-scripts-autocomplete.plugin.zsh
+++ b/zsh-npm-scripts-autocomplete.plugin.zsh
@@ -29,11 +29,11 @@ __znsaArgsLength() {
 __znsaYarnRunCompletion() {
   # Return if the length of arguments is not 2 or 3
   local argsLength="$(__znsaArgsLength)"
-  [[ "$argsLength" -ne "2" || "$argsLength" -ne "3" ]] && return
+  [[ "$argsLength" -ne "2" && "$argsLength" -ne "3" ]] && return
 
   # Return if package.json is not found
   local pkgJson="$(__znsaFindFile package.json)"
-  [[ "$pkgJson" = "" ]] && return
+  [[ "$pkgJson" == "" ]] && return
 
   # Handle `yarn <script>` command
   if [[ "$argsLength" = "2" ]]; then
@@ -49,7 +49,7 @@ __znsaYarnRunCompletion() {
   # Handle `yarn/pnpm remove/rm <dependency>` command
   if [[ "$argsLength" = "3" ]]; then
     # Return if the command is not `remove` or `rm`
-    [[ ! "$words[2]" in "rm" "remove" ]] && return
+    [[ "${words[2]}" != "rm" && "${words[2]}" != "remove" ]] && return
 
     # Get the dependencies
     local -a options=(${(f)"$(__znsaGetDependencies $pkgJson)"})
@@ -61,40 +61,6 @@ __znsaYarnRunCompletion() {
   fi
 }
 
-__znsaNpmRunCompletion() {
-  # Return if the length of arguments is not 3
-  [[ ! "$(__znsaArgsLength)" -ne "3" ]] && return
-
-  # Return if package.json is not found
-  local pkgJson="$(__znsaFindFile package.json)"
-  [[ "$pkgJson" = "" ]] && return
-
-  # Handle `npm run <script>` command
-  if [[ "$words[2]" == "run" ]]; then
-    # Get the scripts
-    local -a options=(${(f)"$(__znsaGetScripts $pkgJson)"})
-    [[ "$#options" = 0 ]] && return
-
-    # Describe the options for autocompletion
-    _describe 'values' options
-    return
-  fi
-
-  # Handle `npm uninstall <dependency>` command
-  if [[ "$words[2]" == "uninstall" ]]; then
-    # Get the dependencies
-    local -a options=(${(f)"$(__znsaGetDependencies $pkgJson)"})
-    [[ "$#options" = 0 ]] && return
-
-    # Describe the options for autocompletion
-    _describe 'values' options
-    return
-  fi
-}
-
-alias nr="npm run"
-compdef __znsaYarnRunCompletion yarn
-compdef __znsaYarnRunCompletion nr
 compdef __znsaYarnRunCompletion pnpm
-compdef __znsaNpmRunCompletion npm
+compdef __znsaYarnRunCompletion yarn
 compdef __znsaNpmRunCompletion bun

--- a/zsh-npm-scripts-autocomplete.plugin.zsh
+++ b/zsh-npm-scripts-autocomplete.plugin.zsh
@@ -1,6 +1,12 @@
 local _plugin_path=$0
 local _PWD=`echo $_plugin_path | sed -e 's/\/zsh-npm-scripts-autocomplete\.plugin\.zsh//'`
 __zna_pwd="$_PWD"
+
+__znsaGetDependencies() {
+  local pkgJson="$1"
+  node "$__zna_pwd/getDependencies.js" "$pkgJson" 2>/dev/null
+}
+
 __znsaGetScripts() {
   local pkgJson="$1"
   node "$__zna_pwd/getScripts.js" "$pkgJson" 2>/dev/null
@@ -21,42 +27,74 @@ __znsaArgsLength() {
 }
 
 __znsaYarnRunCompletion() {
-  [[ ! "$(__znsaArgsLength)" = "2" ]] && return
+  # Return if the length of arguments is not 2 or 3
+  local argsLength="$(__znsaArgsLength)"
+  [[ "$argsLength" -ne "2" || "$argsLength" -ne "3" ]] && return
+
+  # Return if package.json is not found
   local pkgJson="$(__znsaFindFile package.json)"
   [[ "$pkgJson" = "" ]] && return
-  local -a options
-  options=(${(f)"$(__znsaGetScripts $pkgJson)"})
-  [[ "$#options" = 0 ]] && return
-  _describe 'values' options
+
+  # Handle `yarn <script>` command
+  if [[ "$argsLength" = "2" ]]; then
+    # Get the scripts
+    local -a options=(${(f)"$(__znsaGetScripts $pkgJson)"})
+    [[ "$#options" = 0 ]] && return
+
+    # Describe the options for autocompletion
+    _describe 'values' options
+    return
+  fi
+
+  # Handle `yarn/pnpm remove/rm <dependency>` command
+  if [[ "$argsLength" = "3" ]]; then
+    # Return if the command is not `remove` or `rm`
+    [[ ! "$words[2]" in "rm" "remove" ]] && return
+
+    # Get the dependencies
+    local -a options=(${(f)"$(__znsaGetDependencies $pkgJson)"})
+    [[ "$#options" = 0 ]] && return
+
+    # Describe the options for autocompletion
+    _describe 'values' options
+    return
+  fi
 }
 
-## to lazy to handler different number of arguments
-## just copy and paste it
 __znsaNpmRunCompletion() {
-  [[ ! "$(__znsaArgsLength)" = "3" ]] && return
+  # Return if the length of arguments is not 3
+  [[ ! "$(__znsaArgsLength)" -ne "3" ]] && return
+
+  # Return if package.json is not found
   local pkgJson="$(__znsaFindFile package.json)"
   [[ "$pkgJson" = "" ]] && return
-  local -a options
-  options=(${(f)"$(__znsaGetScripts $pkgJson)"})
-  [[ "$#options" = 0 ]] && return
-  _describe 'values' options
-}
 
-__znsaHandleYarn() {
-  __znsaYarnRunCompletion
-}
+  # Handle `npm run <script>` command
+  if [[ "$words[2]" == "run" ]]; then
+    # Get the scripts
+    local -a options=(${(f)"$(__znsaGetScripts $pkgJson)"})
+    [[ "$#options" = 0 ]] && return
 
-__znsaHandleNpm(){
-  case "${words[2]}" in
-    run)
-      __znsaNpmRunCompletion
-      ;;
-  esac
+    # Describe the options for autocompletion
+    _describe 'values' options
+    return
+  fi
+
+  # Handle `npm uninstall <dependency>` command
+  if [[ "$words[2]" == "uninstall" ]]; then
+    # Get the dependencies
+    local -a options=(${(f)"$(__znsaGetDependencies $pkgJson)"})
+    [[ "$#options" = 0 ]] && return
+
+    # Describe the options for autocompletion
+    _describe 'values' options
+    return
+  fi
 }
 
 alias nr="npm run"
 compdef __znsaYarnRunCompletion yarn
 compdef __znsaYarnRunCompletion nr
 compdef __znsaYarnRunCompletion pnpm
-compdef __znsaHandleNpm npm
-compdef __znsaHandleNpm bun
+compdef __znsaNpmRunCompletion npm
+compdef __znsaNpmRunCompletion bun


### PR DESCRIPTION
- **NPM Completion Conflict**: The official npm completion from NPM generates completion settings in ~/.zshrc, which conflicts with this plugin. Since it already supports completion for uninstall <package>, there is no need to duplicate this functionality to avoid conflicts.

- **Support for pnpm/yarn**: The generated completions for pnpm and yarn previously did not support completing run script and remove dependency. This PR adds support for remove <dependency> completion, improving the user experience for these package managers.